### PR TITLE
 Replaced symlinks for "latest" and "second-latest" with link simulation

### DIFF
--- a/osutil/simulate_link.go
+++ b/osutil/simulate_link.go
@@ -1,0 +1,29 @@
+package osutil
+
+import (
+	"io/ioutil"
+	"path/filepath"
+)
+
+// CreateSimLink creates a simulated link which is just a text file containing the real path
+// dst is the file name to point to
+// src is the file name of the link
+func CreateSimLink(dst, src string) error {
+	dataBytes := []byte(dst)
+	err := ioutil.WriteFile(src, dataBytes, 0644)
+	return err
+}
+
+// ReadSimLink a simulated link which is just a text file containing the real path
+// link is the file name of the link
+func ReadSimLink(link string) (string, error) {
+	path := ""
+	bytes, err := ioutil.ReadFile(link)
+	if err == nil {
+		path = string(bytes)
+		if !filepath.IsAbs(path) {
+			path, err = filepath.Abs(filepath.Join(filepath.Dir(link), path))
+		}
+	}
+	return path, err
+}


### PR DESCRIPTION
- Symbolic links on Windows are problematic, because
   - on Windows 7: only work with Administrator privileges
   - on Windows 10: only work with Administrator privileges or when the Developer Mode is enabled
- Therefore, the following symbolic links are now replaced by simple text files conatining the target path:
   - `.jiri_root/update_history/latest`
   - `.jiri_root/update_history/second-latest`
- The functions to handle these simulated links are in `osutil/simulate_link.go`