### PR TITLE
Fixed symlink replacement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "cwd": "F:\\jiri\\workdir1",
+            "program": "${fileDirname}",
+            "env": {
+                "PATH": "C:\\Windows\\system32;C:\\Windows;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\Git\\cmd"
+            },
+            "args": ["-vv", "${fileBasenameNoExtension}"]
+        }
+    ]
+}

--- a/project/project.go
+++ b/project/project.go
@@ -522,6 +522,10 @@ func LocalProjects(jirix *jiri.X, scanMode ScanMode) (Projects, error) {
 	if err != nil {
 		return nil, err
 	}
+	latestSnapshotFile, err := osutil.ReadSimLink(latestSnapshot)
+	if err != nil {
+		return nil, err
+	}
 	if scanMode == FastScan && latestSnapshotExists {
 		// Fast path: Full scan was not requested, and we have a snapshot containing
 		// the latest update.  Check that the projects listed in the snapshot exist
@@ -530,7 +534,7 @@ func LocalProjects(jirix *jiri.X, scanMode ScanMode) (Projects, error) {
 		// An error will be returned if the snapshot contains remote imports, since
 		// that would cause an infinite loop; we'd need local projects, in order to
 		// load the snapshot, in order to determine the local projects.
-		snapshotProjects, _, err := LoadSnapshotFile(jirix, latestSnapshot)
+		snapshotProjects, _, err := LoadSnapshotFile(jirix, latestSnapshotFile)
 		if err != nil {
 			if err == errVersionMismatch {
 				return loadLocalProjectsSlow(jirix)

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 
+	"fuchsia.googlesource.com/jiri/osutil"
+
 	"fuchsia.googlesource.com/jiri"
 	"fuchsia.googlesource.com/jiri/gitutil"
 	"fuchsia.googlesource.com/jiri/jiritest"
@@ -200,8 +202,13 @@ func TestLocalProjects(t *testing.T) {
 	if err := os.MkdirAll(jirix.UpdateHistoryDir(), 0755); err != nil {
 		t.Fatalf("MkdirAll(%v) failed: %v", jirix.UpdateHistoryDir(), err)
 	}
-	if err := manifest.ToFile(jirix, jirix.UpdateHistoryLatestLink()); err != nil {
-		t.Fatalf("manifest.ToFile(%v) failed: %v", jirix.UpdateHistoryLatestLink(), err)
+	latestSnapshot := jirix.UpdateHistoryLatestLink()
+	latestSnapshotFile, err := osutil.ReadSimLink(latestSnapshot)
+	if err != nil {
+		t.Fatalf("osutil.ReadSimLink(%v) failed: %v", latestSnapshot, err)
+	}
+	if err := manifest.ToFile(jirix, latestSnapshotFile); err != nil {
+		t.Fatalf("manifest.ToFile(%v) failed: %v", latestSnapshotFile, err)
 	}
 
 	// LocalProjects with scanMode = FastScan should only find the first


### PR DESCRIPTION
- Some usage of `UpdateHistoryLatestLink()` has been fixed, because now the returned path is not a symbolic link anymore